### PR TITLE
feat: Append token of epoch millis to endpoint links

### DIFF
--- a/src/app/(components)/cards/item-card.tsx
+++ b/src/app/(components)/cards/item-card.tsx
@@ -22,7 +22,7 @@ import { WeaponItem } from '@/app/(data)/items/types/WeaponItem'
 import { ArmorInfo } from '@/features/armor-calculator/ArmorInfo'
 import { getArrayOfLength } from '@/features/build/lib/getArrayOfLength'
 import getItemBuildStats from '@/features/items/actions/getItemBuildStats'
-import { cleanItemName } from '@/features/items/lib/cleanItemName'
+import { itemShareEndpoint } from '@/features/items/lib/cleanItemName'
 import { DescriptionWithTags } from '@/features/ui/DescriptionWithTags'
 import { Tooltip } from '@/features/ui/Tooltip'
 import { cn } from '@/lib/classnames'
@@ -351,11 +351,7 @@ export function ItemCard({
             className="relative flex items-center justify-center"
             aria-label="Share Item Link"
             onClick={() => {
-              copy(
-                `https://remnant2toolkit.com/endpoint/item/${cleanItemName(
-                  item,
-                )}`,
-              )
+              copy(itemShareEndpoint(item))
               toast.success('Copied link to clipboard')
             }}
           >

--- a/src/app/(components)/dialogs/item-info-dialog.tsx
+++ b/src/app/(components)/dialogs/item-info-dialog.tsx
@@ -21,7 +21,7 @@ import { TraitItem } from '@/app/(data)/items/types/TraitItem'
 import { WeaponItem } from '@/app/(data)/items/types/WeaponItem'
 import { ArmorInfo } from '@/features/armor-calculator/ArmorInfo'
 import { WeaponInfo } from '@/features/items/components/WeaponInfo'
-import { cleanItemName } from '@/features/items/lib/cleanItemName'
+import { itemShareEndpoint } from '@/features/items/lib/cleanItemName'
 import { Item } from '@/features/items/types'
 import { DescriptionWithTags } from '@/features/ui/DescriptionWithTags'
 import { capitalize } from '@/lib/capitalize'
@@ -71,11 +71,7 @@ export function ItemInfoDialog({ open, item, onClose }: Props) {
             <BaseButton
               aria-label="Copy link to item"
               onClick={() => {
-                copy(
-                  `https://remnant2toolkit.com/endpoint/item/${cleanItemName(
-                    item,
-                  )}`,
-                )
+                copy(itemShareEndpoint(item))
                 toast.success('Copied link to clipboard')
               }}
             >

--- a/src/app/(endpoints)/i/[itemName]/layout.tsx
+++ b/src/app/(endpoints)/i/[itemName]/layout.tsx
@@ -7,6 +7,7 @@ import { TraitItem } from '@/app/(data)/items/types/TraitItem'
 import { WeaponItem } from '@/app/(data)/items/types/WeaponItem'
 
 import ItemPage from './page'
+import { itemEndpoint } from '@/features/items/lib/cleanItemName'
 
 function getItemFromParam(itemName: string) {
   // need to remove all punctuation and spaces from itemName
@@ -75,7 +76,7 @@ export async function generateMetadata(
       title,
       description,
       siteName: 'Remnant 2 Toolkit',
-      url: `https://remnant2toolkit.com/endpoint/item/${item.name}`,
+      url: itemEndpoint(item),
       images: [
         {
           url: `https://${process.env.NEXT_PUBLIC_IMAGE_URL}${item.imagePath}`,

--- a/src/app/endpoint/item/[itemName]/layout.tsx
+++ b/src/app/endpoint/item/[itemName]/layout.tsx
@@ -7,6 +7,7 @@ import { TraitItem } from '@/app/(data)/items/types/TraitItem'
 import { WeaponItem } from '@/app/(data)/items/types/WeaponItem'
 
 import ItemPage from './page'
+import { itemEndpoint } from '@/features/items/lib/cleanItemName'
 
 function getItemFromParam(itemName: string) {
   // need to remove all punctuation and spaces from itemName
@@ -75,7 +76,7 @@ export async function generateMetadata(
       title,
       description,
       siteName: 'Remnant 2 Toolkit',
-      url: `https://remnant2toolkit.com/endpoint/item/${item.name}`,
+      url: itemEndpoint(item),
       images: [
         {
           url: `https://${process.env.NEXT_PUBLIC_IMAGE_URL}${item.imagePath}`,

--- a/src/features/items/lib/cleanItemName.ts
+++ b/src/features/items/lib/cleanItemName.ts
@@ -3,3 +3,18 @@ import { Item } from '../types'
 export function cleanItemName(item: Item) {
   return item.name.replace(/[^a-zA-Z0-9]/g, '').toLowerCase()
 }
+
+/**
+ * Builds a link to the provided item's endpoint. 
+ */
+export function itemEndpoint(item: Item) {
+  return `https://remnant2toolkit.com/endpoint/item/${cleanItemName(item)}`
+}
+
+/**
+ * Builds a link to the provided item's endpoint and appends a unique token. 
+ * This is useful for cases such as shared URLs where caching is undesirable. 
+ */
+export function itemShareEndpoint(item: Item) {
+  return `${itemEndpoint(item)}?t=${Date.now()}`
+}


### PR DESCRIPTION
[Description]
------------------------------------------------------------------------ 
Closes issue #111

Adds new methods to create item endpoint links with an appended token. The current epoch millis is used here to match what the build links do.

These replace prior references, including the two share button use sites:
* Item cards
* Item info dialogs

[Validation]
------------------------------------------------------------------------
* Built and deployed local instance via docker as per LOCALSETUP.md
* Navigated to http://localhost:3000/item-lookup
* Did a search, clicked an arbitrary item's share button, and opened it
* Confirmed that the (real) site loaded properly and had a token
* Repeated this process for http://localhost:3000/endpoint/item/
* Confirmed that a link of form http://localhost:3000/i/ still loads