### PR TITLE
Initial theming setup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "masonic": "3.7.0",
         "next": "14.1.0",
         "next-auth": "4.24.7",
+        "next-themes": "0.3.0",
         "papaparse": "5.4.1",
         "patreon": "0.4.1",
         "react": "18.2.0",
@@ -9421,6 +9422,15 @@
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
       "bin": {
         "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/next-themes": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.3.0.tgz",
+      "integrity": "sha512-/QHIrsYpd6Kfk7xakK4svpDI5mmXP0gfvCoJdGpZQ2TOrQZmsW0QxjaiLn8wbIKjtm4BTSqLoix4lxYYOnLJ/w==",
+      "peerDependencies": {
+        "react": "^16.8 || ^17 || ^18",
+        "react-dom": "^16.8 || ^17 || ^18"
       }
     },
     "node_modules/next/node_modules/@swc/helpers": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "masonic": "3.7.0",
     "next": "14.1.0",
     "next-auth": "4.24.7",
+    "next-themes": "0.3.0",
     "papaparse": "5.4.1",
     "patreon": "0.4.1",
     "react": "18.2.0",

--- a/src/app/(components)/buttons/global-action-buttons/global-action-buttons.tsx
+++ b/src/app/(components)/buttons/global-action-buttons/global-action-buttons.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { ArrowUpIcon, BugAntIcon } from '@heroicons/react/24/solid'
+import { ArrowUpIcon, BugAntIcon, SunIcon } from '@heroicons/react/24/solid'
 import { useState } from 'react'
 import { toast } from 'react-toastify'
 
@@ -8,10 +8,12 @@ import { BaseButton } from '@/app/(components)/_base/button'
 import { BugReportPrompt } from '@/app/(components)/alerts/bug-report-prompt'
 import { ReportBug } from '@/app/(components)/buttons/global-action-buttons/actions'
 import { NAV_ITEMS } from '@/features/navigation/constants'
+import { ToggleThemeButton } from '@/app/(utils)/theme-utils'
 
 export function GlobalActionButtons() {
   return (
     <div className="fixed bottom-[8px] right-[8px] z-20 flex items-center justify-center gap-x-1">
+      <ToggleThemeButton />
       <ReportBugButton />
       <ChangeLogButton />
       <BackToTopButton />

--- a/src/app/(utils)/theme-utils.tsx
+++ b/src/app/(utils)/theme-utils.tsx
@@ -1,0 +1,27 @@
+'use client'
+
+import { MoonIcon, SunIcon } from '@heroicons/react/24/solid'
+import { ThemeProvider, useTheme } from 'next-themes'
+import { BaseButton } from '../(components)/_base/button'
+
+export function ThemeSelection({ children }: { children: React.ReactNode }) {
+    return <ThemeProvider attribute="class" defaultTheme='system' enableSystem>{children}</ThemeProvider>
+}
+
+export function ToggleThemeButton() {
+    const { setTheme, resolvedTheme } = useTheme()
+
+    if (resolvedTheme === 'dark') {
+        return (
+            <BaseButton onClick={() => setTheme('light')} color="white">
+                <SunIcon className="h-5 w-5" />
+            </BaseButton>
+        )
+    } else {
+        return (
+            <BaseButton onClick={() => setTheme('dark')} color="dark">
+                <MoonIcon className="h-5 w-5" />
+            </BaseButton>
+        )
+    }
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2,9 +2,16 @@
 @tailwind components;
 @tailwind utilities;
 
-body {
-  color: #ffffff;
-  background: #11001c;
+@layer base {
+  html[data-theme='default'] {
+    --color-foreground: #11001c;
+    --color-background: #f5fafc;
+  }
+
+  html[data-theme='dark'] {
+    --color-foreground: #f5fafc;
+    --color-background: #11001c;
+  }
 }
 
 /** Fixes the misalignment when exporting builds to images */

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import { Inter } from 'next/font/google'
+import { ThemeProvider } from 'next-themes'
 
 import { NavBar } from '@/features/navigation/NavBar'
 import { Footer } from '@/features/ui/Footer'
@@ -16,12 +17,11 @@ import { GlobalActionButtons } from '@/app/(components)/buttons/global-action-bu
 import { PreloadResources } from '@/features/ui/PreloadResources'
 
 import { SessionProvider } from '../features/auth/components/SessionProvider'
+import { ThemeSelection } from './(utils)/theme-utils'
 
 const inter = Inter({ subsets: ['latin'] })
 
-export const viewport: Viewport = {
-  themeColor: '#581c87',
-}
+export const viewport: Viewport = {}
 
 export default async function RootLayout({
   children,
@@ -29,7 +29,8 @@ export default async function RootLayout({
   children: React.ReactNode
 }) {
   return (
-    <html lang="en" className="dark">
+    <html lang="en" suppressHydrationWarning>
+      <head />
       <body
         className={cn(
           'relative flex min-h-fit flex-col items-center justify-start',
@@ -38,26 +39,26 @@ export default async function RootLayout({
       >
         <PreloadResources />
         <SessionProvider>
-          <GlobalActionButtons />
-          {/* <div className="w-full bg-blue-950 p-1 text-center text-sm">
-            <BaseText>
-              Use the <BaseCode>Include Patch Affected Builds</BaseCode> filter
-              to see all patch affected builds! Update your pre-patch builds
-              now!
-            </BaseText>
-          </div> */}
-          <div className="flex h-full w-full max-w-7xl grow flex-col items-start justify-start">
-            <header className="w-full">
-              <NavBar />
-            </header>
-
-            <main className="flex h-full min-h-screen w-full grow flex-col items-center justify-start p-4 pt-0">
-              <ToastContainer theme="dark" pauseOnFocusLoss={false} />
-              {children}
-            </main>
-          </div>
-
-          <Footer />
+          <ThemeSelection>
+            <GlobalActionButtons />
+            {/* <div className="w-full bg-blue-950 p-1 text-center text-sm">
+              <BaseText>
+                Use the <BaseCode>Include Patch Affected Builds</BaseCode> filter
+                to see all patch affected builds! Update your pre-patch builds
+                now!
+              </BaseText>
+            </div> */}
+            <div className="flex h-full w-full max-w-7xl grow flex-col items-start justify-start">
+              <header className="w-full">
+                <NavBar />
+              </header>
+              <main className="flex h-full min-h-screen w-full grow flex-col items-center justify-start p-4 pt-0">
+                <ToastContainer pauseOnFocusLoss={false} />
+                {children}
+              </main>
+            </div>
+            <Footer />
+          </ThemeSelection>
         </SessionProvider>
         <Analytics />
         {/* <SpeedInsights /> */}

--- a/src/features/ui/Footer.tsx
+++ b/src/features/ui/Footer.tsx
@@ -4,11 +4,11 @@ import { cn } from '@/lib/classnames'
 
 import { NAV_ITEMS } from '../navigation/constants'
 
-const aClass = 'text-gray-300 hover:text-primary-400 underline'
+const aClass = 'text-slate-900 dark:text-gray-300 hover:text-primary-400 underline'
 
 export function Footer() {
   return (
-    <footer className="border-secondary-900 mt-8 flex w-full items-center justify-center border-t bg-black p-4 text-left text-sm text-gray-400">
+    <footer className="border-secondary-900 mt-8 flex w-full items-center justify-center border-t bg-white dark:bg-black p-4 text-left text-sm text-slate-900 dark:text-gray-400">
       <div className="max-w-2xl gap-2">
         <div className="flex w-full flex-row items-center justify-center gap-4 p-2">
           <a
@@ -20,7 +20,7 @@ export function Footer() {
               alt="Remnant 2 Toolkit on GitHub"
               width={32}
               height={32}
-              className="h-8 w-8"
+              className="h-8 w-8 invert dark:invert-0"
               loading="eager"
             />
           </a>
@@ -33,7 +33,7 @@ export function Footer() {
               alt="Support on Patreon"
               width={32}
               height={32}
-              className="h-6 w-6"
+              className="h-6 w-6 invert dark:invert-0"
               loading="eager"
             />
           </a>
@@ -43,7 +43,7 @@ export function Footer() {
               alt="Join the Remnant 2 Toolkit Discord"
               width={32}
               height={32}
-              className="h-6 w-6"
+              className="h-6 w-6 invert dark:invert-0"
               loading="eager"
             />
           </a>
@@ -53,7 +53,7 @@ export function Footer() {
               alt="Remnant 2 Toolkit on Twitter"
               width={32}
               height={32}
-              className="h-6 w-6"
+              className="h-6 w-6 invert dark:invert-0"
               loading="eager"
             />
           </a>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -3,7 +3,7 @@ const colors = require('tailwindcss/colors')
 
 /** @type {import('tailwindcss').Config} */
 module.exports = {
-  darkMode: 'class',
+  darkMode: 'selector',
   content: [
     './src/pages/**/*.{js,ts,jsx,tsx,mdx}',
     './src/components/**/*.{js,ts,jsx,tsx,mdx}',
@@ -21,8 +21,8 @@ module.exports = {
           'conic-gradient(from 180deg at 50% 50%, var(--tw-gradient-stops))',
       },
       colors: {
-        background: '#11001c',
-        surface: '#000000',
+        surface: 'rgb(var(--color-foreground) / <alpha-value>)',
+        background: 'rgb(var(--color-background) / <alpha-value>)',
         primary: colors.cyan,
         secondary: colors.violet,
         accent1: colors.yellow,


### PR DESCRIPTION
This is a minimal first commit to enable some prototyping:
* A dark/light theme toggle button
* (Some) dynamic colors
* POC of inverted footer icons to gauge how badly SVGs are needed

Light mode looks terrible, as expected.  
Opening an early PR to provide a sense of the general direction. 
Longer term I imagine this becomes a profile preference, but for now a local button is plenty for testing. 

You can find details on `next-themes` [here.](https://github.com/pacocoursey/next-themes)

![image](https://github.com/joshpayette/remnant2-toolkit/assets/2497126/4c7e9ff8-4e90-43b6-8409-1603e1d15671)

![image](https://github.com/joshpayette/remnant2-toolkit/assets/2497126/bfa4ddb6-ad37-4bac-80c0-e2652fe54a88)
