### PR TITLE
Append undiscovered count to item tracker category progress labels

### DIFF
--- a/src/app/tracker/item-list.tsx
+++ b/src/app/tracker/item-list.tsx
@@ -37,14 +37,9 @@ function getCategoryProgressLabel({
   filteredItems: Item[]
   discoveredItemIds: string[]
 }) {
-  const discoveredCount = filteredItems.reduce((acc, item) => {
-    if (discoveredItemIds.includes(item.id)) return acc + 1
-    return acc
-  }, 0)
-  const selectedCategoryProgress = parseFloat(
-    ((discoveredCount / filteredItems.length) * 100).toFixed(2),
-  )
-  return selectedCategoryProgress
+  const undiscoveredCount = filteredItems.reduce((acc, item) => discoveredItemIds.includes(item.id) ? acc : acc + 1, 0);
+  const filteredItemsCount = filteredItems.length;
+  return `${(((filteredItemsCount - undiscoveredCount) / filteredItemsCount) * 100).toFixed(2)}% (${undiscoveredCount} undiscovered)`
 }
 
 function getFilteredItemList(
@@ -323,7 +318,6 @@ export function ItemList({}: Props) {
                           ),
                           discoveredItemIds,
                         })}
-                        %
                       </h2>
                     </div>
                     <ChevronDownIcon


### PR DESCRIPTION
This commit expands the percentage complete to also indicate how many undiscovered items said percentage represents.

Note that this counts all items regardless of filters, in order to remain aligned with the percentages.

![image](https://github.com/joshpayette/remnant2-toolkit/assets/2497126/10b846c6-a2fa-4f92-aad2-792cf1d52c38)

![image](https://github.com/joshpayette/remnant2-toolkit/assets/2497126/7b1194bf-afe7-4f2c-958a-24bb72dc3e16)
