### PR TITLE
Lazy-load theme toggle button

### DIFF
--- a/src/app/(components)/buttons/global-action-buttons/global-action-buttons.tsx
+++ b/src/app/(components)/buttons/global-action-buttons/global-action-buttons.tsx
@@ -8,7 +8,10 @@ import { BaseButton } from '@/app/(components)/_base/button'
 import { BugReportPrompt } from '@/app/(components)/alerts/bug-report-prompt'
 import { ReportBug } from '@/app/(components)/buttons/global-action-buttons/actions'
 import { NAV_ITEMS } from '@/app/(types)/navigation'
-import { ToggleThemeButton } from '@/app/(utils)/theme-utils'
+import dynamic from 'next/dynamic'
+
+// Lazy-load the theme toggle, since it relies on client context
+const ToggleThemeButton = dynamic(() => import('./theme-toggle-button'), { ssr: false })
 
 export function GlobalActionButtons() {
   return (

--- a/src/app/(components)/buttons/global-action-buttons/theme-toggle-button.tsx
+++ b/src/app/(components)/buttons/global-action-buttons/theme-toggle-button.tsx
@@ -1,0 +1,30 @@
+import { SunIcon, MoonIcon } from "@heroicons/react/24/solid"
+import { useTheme } from "next-themes"
+import { BaseButton } from "../../_base/button"
+
+// WARNING: This component is not hydration-safe
+// https://github.com/pacocoursey/next-themes#avoid-hydration-mismatch
+export default function ToggleThemeButton() {
+    const { setTheme, forcedTheme, resolvedTheme } = useTheme()
+
+    // Temporary feature gate
+    if (forcedTheme) {
+        // If a theme is being forced, there is no alternate theme to toggle to
+        // Disable the toggle option in this case
+        return
+    }
+
+    if (resolvedTheme === 'dark') {
+        return (
+        <BaseButton onClick={() => setTheme('light')} color="white">
+            <SunIcon className="h-5 w-5" />
+        </BaseButton>
+        )
+    } else {
+        return (
+        <BaseButton onClick={() => setTheme('dark')} color="dark">
+            <MoonIcon className="h-5 w-5" />
+        </BaseButton>
+        )
+    }
+}

--- a/src/app/(utils)/theme-utils.tsx
+++ b/src/app/(utils)/theme-utils.tsx
@@ -1,10 +1,7 @@
 'use client'
 
-import { MoonIcon, SunIcon } from '@heroicons/react/24/solid'
-import { ThemeProvider, useTheme } from 'next-themes'
+import { ThemeProvider } from 'next-themes'
 import { useLocalStorage } from 'usehooks-ts'
-
-import { BaseButton } from '../(components)/_base/button'
 
 export function ThemeSelection({ children }: { children: React.ReactNode }) {
   const [localValue] = useLocalStorage<boolean>('r2tk-theme-toggle', false)
@@ -21,29 +18,4 @@ export function ThemeSelection({ children }: { children: React.ReactNode }) {
       {children}
     </ThemeProvider>
   )
-}
-
-export function ToggleThemeButton() {
-  const { setTheme, forcedTheme, resolvedTheme } = useTheme()
-
-  // Temporary feature gate
-  if (forcedTheme) {
-    // If a theme is being forced, there is no alternate theme to toggle to
-    // Disable the toggle option in this case
-    return
-  }
-
-  if (resolvedTheme === 'dark') {
-    return (
-      <BaseButton onClick={() => setTheme('light')} color="white">
-        <SunIcon className="h-5 w-5" />
-      </BaseButton>
-    )
-  } else {
-    return (
-      <BaseButton onClick={() => setTheme('dark')} color="dark">
-        <MoonIcon className="h-5 w-5" />
-      </BaseButton>
-    )
-  }
 }


### PR DESCRIPTION
Refer to the links in the comments for more context

This commit splits the theme toggle button out into its own file so that it can be default exported
That makes the lazy-loaded import much simpler (and cleaner)
The implementation of the button is otherwise unchanged