### PR TITLE
Minor styling matching for the new item dialog button

### DIFF
--- a/src/app/tracker/item-list.tsx
+++ b/src/app/tracker/item-list.tsx
@@ -161,7 +161,7 @@ export function ItemList({
                   <div className="flex w-full">
                     <button
                       className={cn(
-                        'text-md flex items-center justify-center rounded-full border-transparent bg-background text-center font-bold sm:text-lg',
+                        'text-md text-center font-bold sm:text-lg flex items-center justify-center bg-background hover:bg-background-solid border-b border-secondary-700 hover:border-primary-400',
                       )}
                       onClick={() => {
                         setCurrentFilteredItems(


### PR DESCRIPTION
Basically copy/pasting more stuff from its neighboring element, makes it fit in a bit more naturally 

![image](https://github.com/joshpayette/remnant2-toolkit/assets/2497126/72b0a7c1-a113-4569-9d8c-0715899c0463)
![image](https://github.com/joshpayette/remnant2-toolkit/assets/2497126/9083c092-4383-4746-95e6-27ff3bf600af)
