### PR TITLE
Apply a black background to archetype item info dialogs

### DIFF
--- a/src/app/(components)/dialogs/item-info-dialog.tsx
+++ b/src/app/(components)/dialogs/item-info-dialog.tsx
@@ -25,6 +25,7 @@ import { TraitItem } from '@/app/(data)/items/types/TraitItem'
 import { WeaponItem } from '@/app/(data)/items/types/WeaponItem'
 import { BIOMES, ItemLocation } from '@/app/(types)/locations'
 import { capitalize } from '@/app/(utils)/capitalize'
+import { cn } from '@/app/(utils)/classnames'
 import { itemShareEndpoint } from '@/app/(utils)/clean-item-name'
 
 function generateDungeonLabel(location: ItemLocation) {
@@ -119,7 +120,10 @@ export function ItemInfoDialog({ open, item, onClose }: Props) {
             width={imageSize.width}
             height={imageSize.height}
             alt={item.name}
-            className="h-auto max-h-full w-full max-w-[200px]"
+            className={cn(
+              "h-auto max-h-full w-full max-w-[200px]",
+              ArchetypeItem.isArchetypeItem(item) && 'bg-black',
+            )}
             loading="eager"
           />
         </span>


### PR DESCRIPTION
![image](https://github.com/joshpayette/remnant2-toolkit/assets/2497126/7c67188f-64f6-4017-9f14-d18a38b6d820)
![image](https://github.com/joshpayette/remnant2-toolkit/assets/2497126/c898d3c9-63af-40e6-a8c6-6231ab4c6996)
