### PR TITLE
Retool base button styles to be light-mode friendly

### DIFF
--- a/src/app/(components)/_base/button.tsx
+++ b/src/app/(components)/_base/button.tsx
@@ -19,73 +19,55 @@ const styles = {
   ],
   solid: [
     // Optical border, implemented as the button background to avoid corner artifacts
-    'border-transparent bg-[--btn-border]',
-    // Dark mode: border is rendered on `after` so background is set to button background
-    'dark:bg-[--btn-bg]',
-    // Button background, implemented as foreground layer to stack on top of pseudo-border layer
-    'before:absolute before:inset-0 before:-z-10 before:rounded-[calc(theme(borderRadius.lg)-1px)] before:bg-[--btn-bg]',
-    // Drop shadow, applied to the inset `before` layer so it blends with the border
-    'before:shadow',
-    // Background color is moved to control and shadow is removed in dark mode so hide `before` pseudo
-    'dark:before:hidden',
-    // Dark mode: Subtle white outline is applied using a border
-    'dark:border-white/5',
+    'border-transparent bg-[--btn-bg]',
+    // Subtle outline is applied using a border
+    'border-surface-solid/5',
     // Shim/overlay, inset to match button foreground and used for hover state + highlight shadow
     'after:absolute after:inset-0 after:-z-10 after:rounded-[calc(theme(borderRadius.lg)-1px)]',
     // Inner highlight shadow
     'after:shadow-[shadow:inset_0_1px_theme(colors.white/15%)]',
     // White overlay on hover
     'after:data-[active]:bg-[--btn-hover-overlay] after:data-[hover]:bg-[--btn-hover-overlay]',
-    // Dark mode: `after` layer expands to cover entire button
-    'dark:after:-inset-px dark:after:rounded-lg',
+    // `after` layer expands to cover entire button
+    'after:-inset-px after:rounded-lg',
     // Disabled
     'before:data-[disabled]:shadow-none after:data-[disabled]:shadow-none',
   ],
   outline: [
     // Base
-    'border-zinc-950/10 text-zinc-950 data-[active]:bg-zinc-950/[2.5%] data-[hover]:bg-zinc-950/[2.5%]',
-    // Dark mode
-    'dark:border-white/15 dark:text-white dark:[--btn-bg:transparent] dark:data-[active]:bg-white/5 dark:data-[hover]:bg-white/5',
+    'border-surface-solid/15 text-surface-solid [--btn-bg:transparent] data-[active]:bg-surface-solid/5 data-[hover]:bg-surface-solid/5',
     // Icon
-    '[--btn-icon:theme(colors.zinc.500)] data-[active]:[--btn-icon:theme(colors.zinc.700)] data-[hover]:[--btn-icon:theme(colors.zinc.700)] dark:data-[active]:[--btn-icon:theme(colors.zinc.400)] dark:data-[hover]:[--btn-icon:theme(colors.zinc.400)]',
+    '[--btn-icon:theme(colors.zinc.500)] data-[active]:[--btn-icon:theme(colors.zinc.400)] data-[hover]:[--btn-icon:theme(colors.zinc.400)]',
   ],
   plain: [
     // Base
-    'border-transparent text-zinc-950 data-[active]:bg-zinc-950/5 data-[hover]:bg-zinc-950/5',
-    // Dark mode
-    'dark:text-white dark:data-[active]:bg-white/10 dark:data-[hover]:bg-white/10',
+    'border-transparent text-surface-solid data-[active]:bg-surface-solid/10 data-[hover]:bg-surface-solid/10',
     // Icon
-    '[--btn-icon:theme(colors.zinc.500)] data-[active]:[--btn-icon:theme(colors.zinc.700)] data-[hover]:[--btn-icon:theme(colors.zinc.700)] dark:[--btn-icon:theme(colors.zinc.500)] dark:data-[active]:[--btn-icon:theme(colors.zinc.400)] dark:data-[hover]:[--btn-icon:theme(colors.zinc.400)]',
+    '[--btn-icon:theme(colors.zinc.500)] data-[active]:[--btn-icon:theme(colors.zinc.400)] data-[hover]:[--btn-icon:theme(colors.zinc.400)]',
   ],
   colors: {
     'dark/zinc': [
-      'text-white [--btn-bg:theme(colors.zinc.900)] [--btn-border:theme(colors.zinc.950/90%)] [--btn-hover-overlay:theme(colors.surface.solid/10%)]',
-      'dark:text-white dark:[--btn-bg:theme(colors.zinc.600)] dark:[--btn-hover-overlay:theme(colors.surface.solid/5%)]',
+      'text-surface-solid [--btn-bg:theme(colors.zinc.600)] [--btn-border:theme(colors.zinc.950/90%)] [--btn-hover-overlay:theme(colors.surface.solid/5%)]',
       '[--btn-icon:theme(colors.zinc.400)] data-[active]:[--btn-icon:theme(colors.zinc.300)] data-[hover]:[--btn-icon:theme(colors.zinc.300)]',
     ],
     light: [
-      'text-zinc-950 [--btn-bg:white] [--btn-border:theme(colors.zinc.950/10%)] [--btn-hover-overlay:theme(colors.zinc.950/2.5%)] data-[active]:[--btn-border:theme(colors.zinc.950/15%)] data-[hover]:[--btn-border:theme(colors.zinc.950/15%)]',
-      'dark:text-white dark:[--btn-hover-overlay:theme(colors.surface.solid/5%)] dark:[--btn-bg:theme(colors.zinc.800)]',
-      '[--btn-icon:theme(colors.zinc.500)] data-[active]:[--btn-icon:theme(colors.zinc.700)] data-[hover]:[--btn-icon:theme(colors.zinc.700)] dark:[--btn-icon:theme(colors.zinc.500)] dark:data-[active]:[--btn-icon:theme(colors.zinc.400)] dark:data-[hover]:[--btn-icon:theme(colors.zinc.400)]',
+      'text-text-surface-solid [--btn-bg:theme(colors.zinc.800)] [--btn-border:theme(colors.zinc.950/10%)] [--btn-hover-overlay:theme(colors.surface.solid/5%)] data-[active]:[--btn-border:theme(colors.zinc.950/15%)] data-[hover]:[--btn-border:theme(colors.zinc.950/15%)]',
+      '[--btn-icon:theme(colors.zinc.500)] data-[active]:[--btn-icon:theme(colors.zinc.400)] data-[hover]:[--btn-icon:theme(colors.zinc.400)]',
     ],
     'dark/white': [
-      'text-white [--btn-bg:theme(colors.zinc.900)] [--btn-border:theme(colors.zinc.950/90%)] [--btn-hover-overlay:theme(colors.surface.solid/10%)]',
-      'dark:text-zinc-950 dark:[--btn-bg:white] dark:[--btn-hover-overlay:theme(colors.zinc.950/5%)]',
-      '[--btn-icon:theme(colors.zinc.400)] data-[active]:[--btn-icon:theme(colors.zinc.300)] data-[hover]:[--btn-icon:theme(colors.zinc.300)] dark:[--btn-icon:theme(colors.zinc.500)] dark:data-[active]:[--btn-icon:theme(colors.zinc.400)] dark:data-[hover]:[--btn-icon:theme(colors.zinc.400)]',
+      'text-zinc-950 [--btn-bg:theme(colors.surface.solid)] [--btn-border:theme(colors.zinc.950/90%)] [--btn-hover-overlay:theme(colors.zinc.950/10%)]',
+      '[--btn-icon:theme(colors.zinc.500)] data-[active]:[--btn-icon:theme(colors.zinc.400)] data-[hover]:[--btn-icon:theme(colors.zinc.400)]',
     ],
     dark: [
-      'text-white [--btn-bg:theme(colors.zinc.900)] [--btn-border:theme(colors.zinc.950/90%)] [--btn-hover-overlay:theme(colors.surface.solid/10%)]',
-      'dark:[--btn-hover-overlay:theme(colors.surface.solid/5%)] dark:[--btn-bg:theme(colors.zinc.800)]',
+      'text-white [--btn-bg:theme(colors.zinc.800)] [--btn-border:theme(colors.zinc.950/90%)] [--btn-hover-overlay:theme(colors.surface.solid/5%)]',
       '[--btn-icon:theme(colors.zinc.400)] data-[active]:[--btn-icon:theme(colors.zinc.300)] data-[hover]:[--btn-icon:theme(colors.zinc.300)]',
     ],
     white: [
-      'text-zinc-950 [--btn-bg:white] [--btn-border:theme(colors.zinc.950/10%)] [--btn-hover-overlay:theme(colors.zinc.950/2.5%)] data-[active]:[--btn-border:theme(colors.zinc.950/15%)] data-[hover]:[--btn-border:theme(colors.zinc.950/15%)]',
-      'dark:[--btn-hover-overlay:theme(colors.zinc.950/5%)]',
+      'text-zinc-950 [--btn-bg:white] [--btn-border:theme(colors.zinc.950/10%)] [--btn-hover-overlay:theme(colors.zinc.950/5%)] data-[active]:[--btn-border:theme(colors.zinc.950/15%)] data-[hover]:[--btn-border:theme(colors.zinc.950/15%)]',
       '[--btn-icon:theme(colors.zinc.400)] data-[active]:[--btn-icon:theme(colors.zinc.500)] data-[hover]:[--btn-icon:theme(colors.zinc.500)]',
     ],
     zinc: [
-      'text-white [--btn-hover-overlay:theme(colors.surface.solid/10%)] [--btn-bg:theme(colors.zinc.600)] [--btn-border:theme(colors.zinc.700/90%)]',
-      'dark:[--btn-hover-overlay:theme(colors.surface.solid/5%)]',
+      'text-white [--btn-hover-overlay:theme(colors.surface.solid/5%)] [--btn-bg:theme(colors.zinc.600)] [--btn-border:theme(colors.zinc.700/90%)]',
       '[--btn-icon:theme(colors.zinc.400)] data-[active]:[--btn-icon:theme(colors.zinc.300)] data-[hover]:[--btn-icon:theme(colors.zinc.300)]',
     ],
     indigo: [

--- a/src/app/(components)/buttons/global-action-buttons/theme-toggle-button.client.tsx
+++ b/src/app/(components)/buttons/global-action-buttons/theme-toggle-button.client.tsx
@@ -15,17 +15,11 @@ export default function ToggleThemeButton() {
     return
   }
 
-  if (resolvedTheme === 'dark') {
-    return (
-      <BaseButton onClick={() => setTheme('light')} color="white">
-        <SunIcon className="h-5 w-5" />
-      </BaseButton>
-    )
-  } else {
-    return (
-      <BaseButton onClick={() => setTheme('dark')} color="white">
-        <MoonIcon className="h-5 w-5" />
-      </BaseButton>
-    )
-  }
+  const isDark = resolvedTheme === 'dark'
+  const ButtonIcon = isDark ? SunIcon : MoonIcon
+  return (
+    <BaseButton onClick={() => setTheme(isDark ? 'light' : 'dark')} color="dark/white">
+      <ButtonIcon className="h-5 w-5" />
+    </BaseButton>
+  )
 }


### PR DESCRIPTION
Related: #195  

Largely the same goal as before - promote the explicit `dark:` selectors to be the default, with the assurance that the css vars will handle the theming.  
In a few cases, this requires rewriting explicit colors to named equivalents (e.g. `white` -> `surface-solid`)