### PR TITLE
Add a placeholder for the theme button

### DIFF
--- a/src/app/(components)/buttons/global-action-buttons/global-action-buttons.tsx
+++ b/src/app/(components)/buttons/global-action-buttons/global-action-buttons.tsx
@@ -1,6 +1,10 @@
 'use client'
 
-import { BugAntIcon, Cog6ToothIcon } from '@heroicons/react/24/solid'
+import {
+  BugAntIcon,
+  Cog6ToothIcon,
+  PaintBrushIcon,
+} from '@heroicons/react/24/solid'
 import { AnimatePresence, motion } from 'framer-motion'
 import dynamic from 'next/dynamic'
 import { useState } from 'react'
@@ -16,6 +20,11 @@ const ThemeSelectButton = dynamic(
   () => import('./theme-select-button.client'),
   {
     ssr: false,
+    loading: () => (
+      <BaseButton color="dark/white">
+        <PaintBrushIcon className="h-5 w-5" />
+      </BaseButton>
+    ),
   },
 )
 


### PR DESCRIPTION
Since the button is dynamicaly loaded, there is a
slight delay before it renders. This pop-in was a
minor annoyance before, but with the expandable
GAB menu it is now more apparent. Attempting to
expand these immediately after opening a page
will result in the two non-dynamic icons sliding
into the leftmost slots, then immediately snapping 
to the right when the theme button is loaded.

This commit adds a placeholder theme button that
is visually identical, but non-functional
(and therefore ssr-friendly) for use during this
brief period.