### PR TITLE
Eliminate layout shift on dialog/menu change

### DIFF
--- a/packages/ui/src/common/global-action-buttons/index.tsx
+++ b/packages/ui/src/common/global-action-buttons/index.tsx
@@ -38,10 +38,16 @@ export function GlobalActionButtons({ username }: GlobalActionButtonProps) {
   return (
     <div
       className={cn(
-        'ui-fixed ui-bottom-[8px] ui-right-[8px] ui-flex ui-items-center ui-justify-center ui-gap-x-1',
+        'ui-fixed ui-flex ui-flex-row-reverse ui-w-[98vw] ui-bottom-[8px] ui-gap-x-1',
         ZINDEXES.GLOBAL_ACTION_BUTTONS,
       )}
     >
+      <SettingsButton
+        onToggle={() => {
+          setOpen((prev) => !prev);
+        }}
+      />
+
       <AnimatePresence>
         {open ? (
           <motion.div
@@ -70,12 +76,6 @@ export function GlobalActionButtons({ username }: GlobalActionButtonProps) {
           </motion.div>
         ) : null}
       </AnimatePresence>
-
-      <SettingsButton
-        onToggle={() => {
-          setOpen((prev) => !prev);
-        }}
-      />
     </div>
   );
 }

--- a/packages/ui/src/common/navbar-container/index.tsx
+++ b/packages/ui/src/common/navbar-container/index.tsx
@@ -41,12 +41,12 @@ export function NavbarContainer({
       <nav
         aria-label="Global"
         className={cn(
-          'ui-bg-background ui-fixed ui-mx-auto ui-flex ui-max-h-[80px] ui-w-full ui-max-w-[1500px] ui-items-center ui-justify-between ui-px-4 ui-py-6',
+          'ui-bg-background ui-fixed ui-mx-auto ui-flex ui-max-h-[80px] ui-w-screen ui-max-w-[1500px] ui-items-center ui-justify-between ui-px-6 ui-py-6',
           ZINDEXES.NAVBAR,
         )}
       >
         <div className="ui-flex ui-min-w-[250px]">{logo}</div>
-        <div className="ui-flex ui-w-full ui-justify-end lg:ui-hidden">
+        <div className="ui-flex ui-w-screen ui-justify-end lg:ui-hidden">
           <BaseButton
             aria-label="Open main menu"
             className="-ui-m-2.5 ui-inline-flex ui-items-center ui-justify-center"
@@ -79,7 +79,7 @@ export function NavbarContainer({
         <div className={cn('ui-fixed ui-inset-0', ZINDEXES.DIALOG_BACKDROP)} />
         <Dialog.Panel
           className={cn(
-            'ui-bg-background-solid ui-text-surface-solid sm:ui-ring-secondary-900/10 ui-fixed ui-inset-y-0 ui-right-0 ui-w-full ui-overflow-y-auto ui-px-6 ui-py-6 sm:ui-max-w-sm sm:ui-ring-1',
+            'ui-bg-background-solid ui-text-surface-solid sm:ui-ring-secondary-900/10 ui-fixed ui-inset-y-0 ui-right-0 ui-w-screen ui-overflow-y-auto ui-px-6 ui-py-6 sm:ui-max-w-sm sm:ui-ring-1',
             ZINDEXES.DIALOG,
           )}
         >

--- a/packages/ui/src/styles.css
+++ b/packages/ui/src/styles.css
@@ -374,6 +374,7 @@ Broadly speaking this results in a darker pallete, which contrasts better in lig
 html,
 body {
   padding: 0 !important;
+  scrollbar-gutter: stable;
 }
 
 body {


### PR DESCRIPTION
With the way the footer works, every page has a scrollbar. Additionally, UI components such as dialogs and dropdown menus have accessibility features such as scroll locking enabled by default. This means that the scrollbar is hidden on interaction, which leads to many elements on the pages undergoing a jarring layout shift.

This commit adds a right-side-only gutter for the scrollbar. It then makes a few css tweaks to the navbar and GAB to align them appropriately.