### PR TITLE
adjust warden skill and perk shield and energy regen numbers to estimated base values

### DIFF
--- a/apps/remnant2toolkit/app/(items)/_constants/perk-items.ts
+++ b/apps/remnant2toolkit/app/(items)/_constants/perk-items.ts
@@ -1548,7 +1548,7 @@ export const perkItems: PerkItem[] = [
     dlc: 'dlc3',
     tags: [],
     description:
-      `After 10s of not being damaged, the Warden generates a SHIELD for 23% of their Max Health over 2s.\n` +
+      `After 10s of not being damaged, the Warden generates a SHIELD for 20% of their Max Health over 2s.\n` +
       '\n' +
       `Increases base N'Erudian Energy Reserves for Turret and Drone by 100%.`,
     wikiLinks: ['https://remnant.wiki/Dynamic'],
@@ -1608,7 +1608,7 @@ export const perkItems: PerkItem[] = [
     dlc: 'dlc3',
     tags: [],
     description:
-      `When the Warden's Health drops below 25%, gain a SHIELD for 28.8% of Max Health. Lasts 10s. Can only happen once every 30s.\n` +
+      `When the Warden's Health drops below 25%, gain a SHIELD for 25% of Max Health. Lasts 10s. Can only happen once every 30s.\n` +
       '\n' +
       `While active, increases Movement Speed by 15%.`,
     wikiLinks: [],
@@ -1629,7 +1629,7 @@ export const perkItems: PerkItem[] = [
     dlc: 'dlc3',
     tags: [],
     description:
-      `On Relic Use, grants a SHIELD for 28.8% of Max Health Cannot stack with itself. Lasts 10s or until SHIELD is removed by damage.\n` +
+      `On Relic Use, grants a SHIELD for 25% of Max Health Cannot stack with itself. Lasts 10s or until SHIELD is removed by damage.\n` +
       '\n' +
       `While active, actions which consume N'Erudian Energy have no cost.`,
     wikiLinks: [],

--- a/apps/remnant2toolkit/app/(items)/_constants/skill-items.ts
+++ b/apps/remnant2toolkit/app/(items)/_constants/skill-items.ts
@@ -847,7 +847,7 @@ export const skillItems: SkillItem[] = [
     description:
       'Deploy Shield Drone with 200 Energy Reserves to follow and protect its Warded Target.\n' +
       '\n' +
-      `The Warded Target gains increased Damage Reduction by 10%. When the Warded Target is not at Max SHIELD Capacity, the Drone consumes 25 energy to grant a SHIELD for 11.5% of the target's Max Health once every 1s. All Shields the Drone grants last until removed by damage, or until the Drone alters Warded Targets or is Stowed.\n` +
+      `The Warded Target gains increased Damage Reduction by 10%. When the Warded Target is not at Max SHIELD Capacity, the Drone consumes 25 energy to grant a SHIELD for 10% of the target's Max Health once every 1s. All Shields the Drone grants last until removed by damage, or until the Drone alters Warded Targets or is Stowed.\n` +
       '\n' +
       `When idle 5s the Drone goes Dormant, then gains 1% Energy Regen per second. When depleted of Energy the drone goes Inactive, then gains 2% Energy Regen per second until fully recharged.\n` +
       '\n' +
@@ -877,13 +877,13 @@ export const skillItems: SkillItem[] = [
       '\n' +
       `The Warded Target gains increased Relic Use Speed by 10%. When the Warded Target is not at Max Health, the Drone consumes 10 Energy to heal 10% of the target's Max Health once every 1s.\n` +
       '\n' +
-      `When idle 5s the Drone goes Dormant, then gains 1% Energy Regen per second. When depleted of Energy the Drone goes Inactive, then gains 2.1% Energy Regen per second until fully recharged.\n` +
+      `When idle 5s the Drone goes Dormant, then gains 1% Energy Regen per second. When depleted of Energy the Drone goes Inactive, then gains 2% Energy Regen per second until fully recharged.\n` +
       '\n' +
       `SINGLE PRESS: Drone alters its Warded Target to the targeted ally. Max 1 Heal Drone per target.\n` +
       '\n' +
       `DOUBLE TAP: Drone returns to the Warden and remains by their side.\n` +
       '\n' +
-      `HOLD: Stow Drone to gain 4.2% Energy Regen per second`,
+      `HOLD: Stow Drone to gain 4% Energy Regen per second`,
     wikiLinks: ['https://remnant.wiki/Drone_Heal'],
     linkedItems: {
       archetype: {
@@ -905,13 +905,13 @@ export const skillItems: SkillItem[] = [
       '\n' +
       `The Warded Target gains increased Fire Rate and Total Melee Speed by 10%, and decreased Firearm Charge Time by 10%. While in combat, the Drone attacks the Warded Target's focused enemy, consuming 10 Energy per barrage.\n` +
       '\n' +
-      `When idle 5s the Drone goes Dormant, then gains 1% Energy Regen per second. When depleted of Energy the Drone goes Inactive, then gains 2.1% Energy Regen per second until fully recharged.\n` +
+      `When idle 5s the Drone goes Dormant, then gains 1% Energy Regen per second. When depleted of Energy the Drone goes Inactive, then gains 2% Energy Regen per second until fully recharged.\n` +
       '\n' +
       `SINGLE PRESS: Drone alters its Warded Target to the targeted ally. Max 1 Combat Drone per target.\n` +
       '\n' +
       `DOUBLE TAP: Drone returns to the Warden and remains by their side.\n` +
       '\n' +
-      `HOLD: Stow Drone to gain 4.2% Energy Regen per second.\n`,
+      `HOLD: Stow Drone to gain 4% Energy Regen per second.\n`,
     wikiLinks: ['https://remnant.wiki/Drone_Combat'],
     linkedItems: {
       archetype: {


### PR DESCRIPTION
accounting for level 10 Barrier's 1.15x multiplier and level 2 Expertise's 1.04 multiplier, and some rounding