### PR TITLE
Make color-scheme an explicit part of each theme's css

### DIFF
--- a/packages/ui/src/common/theme-select/theme-selection/index.tsx
+++ b/packages/ui/src/common/theme-select/theme-selection/index.tsx
@@ -85,6 +85,7 @@ export default function ThemeSelection({
   return (
     <ThemeProvider
       defaultTheme={defaultTheme}
+      enableColorScheme={false} // This helper isn't playing nice with the extra themes
       themes={Object.keys(colorThemes)}
       value={colorThemes}
     >

--- a/packages/ui/src/styles.css
+++ b/packages/ui/src/styles.css
@@ -63,6 +63,7 @@ Broadly speaking this results in a darker pallete, which contrasts better in lig
   }
 
   html[data-theme~='light'] {
+    color-scheme: light;
     --color-background: 245 250 252;
     --color-background-solid: 255 255 255;
     --color-surface: 23 29 30;
@@ -130,6 +131,7 @@ Broadly speaking this results in a darker pallete, which contrasts better in lig
   }
 
   html[data-theme~='dark'] {
+    color-scheme: dark;
     --color-background: 17 0 28;
     --color-background-solid: 0 0 0;
     --color-surface: 245 250 252;
@@ -202,6 +204,7 @@ Broadly speaking this results in a darker pallete, which contrasts better in lig
   */
 
   html[data-theme~='nord-snow'] {
+    color-scheme: light;
     --color-background: 236 239 244;
     --color-surface: 46 52 64;
 
@@ -243,6 +246,7 @@ Broadly speaking this results in a darker pallete, which contrasts better in lig
   }
 
   html[data-theme~='nord-polar'] {
+    color-scheme: dark;
     --color-background: 46 52 64;
     --color-surface: 216 222 233;
 
@@ -289,6 +293,7 @@ Broadly speaking this results in a darker pallete, which contrasts better in lig
   */
 
   html[data-theme~='solarized-light'] {
+    color-scheme: light;
     --color-background: 238 232 213;
     --color-surface: 0 43 54;
 
@@ -330,6 +335,7 @@ Broadly speaking this results in a darker pallete, which contrasts better in lig
   }
 
   html[data-theme~='solarized-dark'] {
+    color-scheme: dark;
     --color-background: 7 54 66;
     --color-surface: 253 246 227;
 


### PR DESCRIPTION
https://github.com/pacocoursey/next-themes?tab=readme-ov-file#themeprovider

`enableColorScheme` defaults to on, and seems to have the behavior "set `color-scheme` to `dark` unless the theme is `light`."  
While most other pieces are happy to work with selectors, this apparently doesn't, so resolved themes such as `light nord-snow` are resulting in a `color-scheme` of `dark` still. 

This commit disables this helper, and instead explicitly sets the `color-scheme` hint in each theme's css block. 
This fixes system elements (e.g. scrollbars) incorrectly rendering dark for said themes. 