### PR TITLE
Override toastify CSS

### DIFF
--- a/apps/remnant2toolkit/app/(items)/_components/filters/world-filter.tsx
+++ b/apps/remnant2toolkit/app/(items)/_components/filters/world-filter.tsx
@@ -37,15 +37,9 @@ export function WorldFilter({
   }));
   worldOptions.unshift({ label: DEFAULT_FILTER, value: DEFAULT_FILTER });
 
-  const showDungeons =
-    worldValue === 'Losomn' ||
-    worldValue === `N'Erud` ||
-    worldValue === 'Yaesha' ||
-    worldValue === 'Root Earth' ||
-    worldValue === 'Labyrinth';
-
   let dungeonOptions = [
     { label: DEFAULT_FILTER, value: DEFAULT_FILTER },
+    { label: 'Not World Drop', value: 'Not World Drop' },
     { label: 'World Drop', value: 'World Drop' },
   ];
   switch (worldValue) {
@@ -109,22 +103,20 @@ export function WorldFilter({
           ))}
         </BaseListbox>
       </BaseField>
-      {showDungeons && (
-        <BaseField>
-          <BaseLabel>Dungeon</BaseLabel>
-          <BaseListbox
-            name="dungeon"
-            value={dungeonValue}
-            onChange={onChangeDungeon}
-          >
-            {dungeonOptions.map(({ label, value }) => (
-              <BaseListboxOption key={value} value={value}>
-                <BaseListboxLabel>{label}</BaseListboxLabel>
-              </BaseListboxOption>
-            ))}
-          </BaseListbox>
-        </BaseField>
-      )}
+      <BaseField>
+        <BaseLabel>Dungeon</BaseLabel>
+        <BaseListbox
+          name="dungeon"
+          value={dungeonValue}
+          onChange={onChangeDungeon}
+        >
+          {dungeonOptions.map(({ label, value }) => (
+            <BaseListboxOption key={value} value={value}>
+              <BaseListboxLabel>{label}</BaseListboxLabel>
+            </BaseListboxOption>
+          ))}
+        </BaseListbox>
+      </BaseField>
     </div>
   );
 }

--- a/apps/remnant2toolkit/app/(items)/item-lookup/_components/item-list.tsx
+++ b/apps/remnant2toolkit/app/(items)/item-lookup/_components/item-list.tsx
@@ -175,9 +175,11 @@ function getFilteredItems(
 
   // filter by dungeon
   if (filters.dungeon !== DEFAULT_FILTER) {
-    if (filters.dungeon === 'World Drop') {
+    if (filters.dungeon.includes('World Drop')) {
       filteredItems = filteredItems.filter(
-        (item) => item.location?.dungeon === 'World Drop',
+        (item) =>
+          (item.location?.dungeon === 'World Drop') !==
+          filters.dungeon.startsWith('Not'),
       );
     } else {
       filteredItems = filteredItems.filter((item) => {

--- a/apps/remnant2toolkit/app/(items)/item-lookup/_lib/parse-url-filters.ts
+++ b/apps/remnant2toolkit/app/(items)/item-lookup/_lib/parse-url-filters.ts
@@ -67,7 +67,7 @@ export function parseUrlFilters(
   let dungeon = parsedParams.get(ITEM_FILTER_KEYS.DUNGEON) || DEFAULT_FILTER;
 
   // if the dungeon doesn't match the world, set it to default
-  if (dungeon !== DEFAULT_FILTER && dungeon !== 'World Drop') {
+  if (dungeon !== DEFAULT_FILTER && !dungeon.includes('World Drop')) {
     switch (world) {
       case 'Losomn':
         if (!(LOSOMN_DUNGEONS as string[]).includes(dungeon)) {

--- a/apps/remnant2toolkit/app/(items)/item-tracker/_utils/get-filtered-item-list.ts
+++ b/apps/remnant2toolkit/app/(items)/item-tracker/_utils/get-filtered-item-list.ts
@@ -118,9 +118,11 @@ export function getFilteredItemList(
 
   // filter by dungeon
   if (filters.dungeon !== DEFAULT_FILTER) {
-    if (filters.dungeon === 'World Drop') {
+    if (filters.dungeon.includes('World Drop')) {
       filteredItems = filteredItems.filter(
-        (item) => item.location?.dungeon === 'World Drop',
+        (item) =>
+          (item.location?.dungeon === 'World Drop') !==
+          filters.dungeon.startsWith('Not'),
       );
     } else {
       filteredItems = filteredItems.filter((item) => {

--- a/apps/remnant2toolkit/app/(items)/item-tracker/_utils/parse-url-filters.ts
+++ b/apps/remnant2toolkit/app/(items)/item-tracker/_utils/parse-url-filters.ts
@@ -70,7 +70,7 @@ export function parseUrlFilters(
   let dungeon = parsedParams.get(ITEM_TRACKER_KEYS.DUNGEON) || DEFAULT_FILTER;
 
   // if the dungeon doesn't match the world, set it to default
-  if (dungeon !== DEFAULT_FILTER && dungeon !== 'World Drop') {
+  if (dungeon !== DEFAULT_FILTER && !dungeon.includes('World Drop')) {
     switch (world) {
       case 'Losomn':
         if (!(LOSOMN_DUNGEONS as string[]).includes(dungeon)) {

--- a/packages/ui/src/common/root-layout/index.tsx
+++ b/packages/ui/src/common/root-layout/index.tsx
@@ -1,5 +1,5 @@
-import '@repo/ui/styles.css';
 import 'react-toastify/dist/ReactToastify.min.css';
+import '@repo/ui/styles.css';
 
 import { type Viewport } from 'next';
 import dynamic from 'next/dynamic';


### PR DESCRIPTION
Just swapping the import order.

There are CSS var overrides in our custom styles, but since the base styles were getting imported later they were overridden. 

With this custom toast styles (including light mode) is restored. 